### PR TITLE
Add --after for arg 2 if given

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Or specify another author to get their stats.
 commiter_stats.bash "Nanaa Mihgo"
 ```
 
+Or specify another author and an after date to get their recent stats.
+```bash
+commiter_stats.bash "Nanaa Mihgo" 2020-01-01
+```
+
 It outputs something like
 ```
 Stats for Nanaa Mihgo on master:

--- a/committer_stats.bash
+++ b/committer_stats.bash
@@ -7,6 +7,13 @@ else
     GIT_USER="${1}"
 fi
 
+if [ -z "${2}" ]
+then
+    AfterDate=""
+else
+    AfterDate="--after=${2}"
+fi
+
 main() {
         exit_if_not_repository
         local branch changes
@@ -41,20 +48,20 @@ print_error_and_exit() {
 }
 
 get_branch() {
-    git branch | grep -P '^\*' | cut -d' ' -f2
+    git branch | grep '^\*' | cut -d' ' -f2
 }
 
 lines_changed() {
-    git log --author="${GIT_USER}" --pretty=tformat: --numstat \
+    git log ${AfterDate} --author="${GIT_USER}" --pretty=tformat: --numstat \
         | awk 'BEGIN {ins=0; rem=0}; {ins+=$1; rem+=$2} END {print "+" ins " -" rem}'
 }
 
 get_user_commits() {
-    git rev-list HEAD --count --author="${GIT_USER}"
+    git rev-list HEAD --count --author="${GIT_USER}" ${AfterDate}
 }
 
 get_all_commits() {
-    git rev-list HEAD --count
+    git rev-list HEAD --count ${AfterDate}
 }
 
 calculate_percentage() {
@@ -76,9 +83,8 @@ get_average_delta() {
     fi
 }
 
-
 typical_commit_times() {
-    TZ=UTC git log --author="${GIT_USER}" \
+    TZ=UTC git log ${AfterDate} --author="${GIT_USER}" \
       --pretty=format:"%ad" --date=iso-local \
         | awk '{print $2}' \
         | cut -d: -f1 \


### PR DESCRIPTION
Removed the -P flag in grep since Darwin does not support it.
It seems to work nicely without it.